### PR TITLE
Example of categories integration as menu items.

### DIFF
--- a/djangocms_oscar/cms_app.py
+++ b/djangocms_oscar/cms_app.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from django.utils.translation import ugettext_lazy as _
 from django.conf.urls import patterns
+
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool
 from oscar.app import application
+
+from .menu import CategoriesMenu
 
 
 class OscarApp(CMSApp):
@@ -15,6 +18,7 @@ class OscarApp(CMSApp):
     urls = [
         patterns('', *application.urls[0])
     ]
+    menus = [CategoriesMenu]
     app_name = "oscar"
 
 apphook_pool.register(OscarApp)

--- a/djangocms_oscar/menu.py
+++ b/djangocms_oscar/menu.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from django.utils.translation import ugettext_lazy as _
+
+from cms.menu_bases import CMSAttachMenu
+from menus.base import NavigationNode
+from menus.menu_pool import menu_pool
+from oscar.core.loading import get_model
+
+Category = get_model('catalogue', 'category')
+
+
+class CategoriesMenu(CMSAttachMenu):
+    name = _("Categories Menu")
+
+    def get_nodes(self, request):
+        nodes = []
+        tree = Category.get_tree()
+        for node in tree:
+            parent = node.get_parent()
+            parent_id = parent.slug if parent else None
+            nodes.append(NavigationNode(
+                node.name,
+                node.get_absolute_url(),
+                node.slug,
+                parent_id
+                )
+            )
+        return nodes
+
+
+menu_pool.register_menu(CategoriesMenu)


### PR DESCRIPTION
If needed restriction of categories depth can be used something like this (in `menu.py`):

``` python
for node in tree:
    if node.get_depth() > 1:
        continue
```
